### PR TITLE
delete unnecessary refl tactics

### DIFF
--- a/src/game/world1/level2.lean
+++ b/src/game/world1/level2.lean
@@ -46,7 +46,6 @@ and $y=x+7$, then $2y=2(x+7)$.
 lemma example2 (x y : mynat) (h : y = x + 7) : 2 * y = 2 * (x + 7) :=
 begin
   rw h,
-  refl
   
 
 end

--- a/src/game/world1/level3.lean
+++ b/src/game/world1/level3.lean
@@ -89,7 +89,6 @@ $$\operatorname{succ}(\operatorname{succ}(a)) = \operatorname{succ}(b).$$
 lemma example3 (a b : mynat) (h : succ a = b) : succ(succ(a)) = succ(b) :=
 begin
   rw h,
-  refl,
 
 
 

--- a/src/game/world1/level4.lean
+++ b/src/game/world1/level4.lean
@@ -72,7 +72,6 @@ lemma add_succ_zero (a : mynat) : a + succ(0) = succ(a) :=
 begin
   rw add_succ,
   rw add_zero,
-  refl,
 
 
 

--- a/src/game/world10/level18a.lean
+++ b/src/game/world10/level18a.lean
@@ -18,7 +18,6 @@ begin
   cases h with h2 h3,
   apply h3,
   rw h1,
-  refl,
 end
 
 -- I had 
@@ -59,7 +58,6 @@ begin
   rw succ_add,
   rw succ_add,
   rw add_assoc,
-  refl,
 end
 
 theorem lt_trans (a b c : mynat) : a < b → b < c → a < c :=
@@ -91,7 +89,6 @@ begin
     intro h,
     apply h2,
     rw h,
-    refl,
   intro h,
   cases h with h1 h2,
   split,
@@ -181,7 +178,6 @@ begin
   rw hd,
   repeat {rw succ_add},
   rw add_right_comm,
-  refl,
 
 
 end 
@@ -223,7 +219,6 @@ begin
   rw hd,
   rw mul_add,
   use c * d,
-  refl
 end
 
 theorem mul_le_mul_of_nonneg_right (a b c : mynat) : a ≤ b → 0 ≤ c → a * c ≤ b * c :=
@@ -298,7 +293,6 @@ begin
 intro h,
 induction a with t Ht,
   rw [pow_zero, pow_zero],
-  refl,
 rw [pow_succ, pow_succ],
 apply le_mul,
   assumption,

--- a/src/game/world10/level2.lean
+++ b/src/game/world10/level2.lean
@@ -16,7 +16,6 @@ lemma le_refl (x : mynat) : x ≤ x :=
 begin
   use 0,
   rw add_zero,
-  refl,
 
 
 end 
@@ -45,7 +44,6 @@ so you don't need to `rw add_zero` either! The proof
 
 ```
 use 0,
-refl,
 ```
 
 works.

--- a/src/game/world10/level4.lean
+++ b/src/game/world10/level4.lean
@@ -16,7 +16,6 @@ lemma zero_le (a : mynat) : 0 ≤ a :=
 begin
   use a,
   rw zero_add,
-  refl,
 
 
 end

--- a/src/game/world10/level8.lean
+++ b/src/game/world10/level8.lean
@@ -18,7 +18,6 @@ begin
   use c,
   rw hc,
   rw succ_add,
-  refl,
   
 
 end

--- a/src/game/world2/level3.lean
+++ b/src/game/world2/level3.lean
@@ -39,7 +39,6 @@ begin
   { rw add_succ,
     rw hd,
     rw add_succ,
-    refl
   }
 end
 

--- a/src/game/world2/level5.lean
+++ b/src/game/world2/level5.lean
@@ -34,7 +34,6 @@ begin
   rw one_eq_succ_zero,
   rw add_succ,
   rw add_zero,
-  refl,
 end
 
 end mynat -- hide

--- a/src/game/world2/level6.lean
+++ b/src/game/world2/level6.lean
@@ -53,7 +53,6 @@ begin
   rw add_assoc,
   rw add_comm b c,
   rw ←add_assoc,
-  refl,
 end
 
 /-

--- a/src/game/world3/level2.lean
+++ b/src/game/world3/level2.lean
@@ -31,7 +31,6 @@ begin
   rw mul_succ,
   rw mul_zero,
   rw zero_add,
-  refl
 
   
 end

--- a/src/game/world3/level9.lean
+++ b/src/game/world3/level9.lean
@@ -25,7 +25,6 @@ begin
   rw ←mul_assoc,
   rw mul_comm a, 
   rw mul_assoc,
-  refl,
 
 
 

--- a/src/game/world4/level1.lean
+++ b/src/game/world4/level1.lean
@@ -47,7 +47,6 @@ $0 ^ 0 = 1$.
 lemma zero_pow_zero : (0 : mynat) ^ (0 : mynat) = 1 :=
 begin
   rw pow_zero,
-  refl,
 
 
 end

--- a/src/game/world4/level2.lean
+++ b/src/game/world4/level2.lean
@@ -15,7 +15,6 @@ lemma zero_pow_succ (m : mynat) : (0 : mynat) ^ (succ m) = 0 :=
 begin
   rw pow_succ,
   rw mul_zero,
-  refl,
 
 
 end

--- a/src/game/world4/level3.lean
+++ b/src/game/world4/level3.lean
@@ -17,7 +17,6 @@ begin
   rw pow_succ,
   rw pow_zero,
   rw one_mul,
-  refl,
 
 end
 

--- a/src/game/world8/level12.lean
+++ b/src/game/world8/level12.lean
@@ -21,7 +21,6 @@ $$ d+1 = \operatorname{succ}(d). $$
 theorem add_one_eq_succ (d : mynat) : d + 1 = succ d :=
 begin
   rw succ_eq_add_one,
-  refl,
 
 
 

--- a/src/game/world8/level3.lean
+++ b/src/game/world8/level3.lean
@@ -24,7 +24,6 @@ theorem succ_eq_succ_of_eq {a b : mynat} : a = b → succ(a) = succ(b) :=
 begin
   intro h,
   rw h,
-  refl,
 end
 
 end mynat -- hide

--- a/src/game/world8/level4.lean
+++ b/src/game/world8/level4.lean
@@ -35,7 +35,6 @@ begin
 --  exact succ_eq_succ_of_eq,
   { intro H,
     rw H,
-    refl,
   }
 
 

--- a/src/game/world8/level7.lean
+++ b/src/game/world8/level7.lean
@@ -26,7 +26,6 @@ begin
   { exact add_right_cancel _ _ _}, -- done that way already,
   { intro H, -- H : a = b,
     rw H,
-    refl,
   }
 
 

--- a/src/game/world8/level8.lean
+++ b/src/game/world8/level8.lean
@@ -23,7 +23,6 @@ begin
   apply add_left_cancel a,
   rw h,
   rw add_zero,
-  refl,
 
 
 


### PR DESCRIPTION
Deleted unnecassery refl tactics from the end of some proofs when the state_before was already "no_goals".