### PR TITLE
Add missing lemma keyword for example theorems

### DIFF
--- a/src/game/world10/level2.lean
+++ b/src/game/world10/level2.lean
@@ -30,7 +30,8 @@ attribute [refl] mynat.le_refl
 ...we find that the `refl` tactic will close all goals
 of the form `a ≤ a` as well as all goals of the form `a = a`.
 -/
-example : (0 : mynat) ≤ 0 := begin
+lemma example_10_2 : (0 : mynat) ≤ 0 :=
+begin
   refl
 end
 

--- a/src/game/world2/level6.lean
+++ b/src/game/world2/level6.lean
@@ -89,8 +89,9 @@ tactic really), and can nail some really tedious-for-a-human-to-solve
 goals. For example check out this one-line proof:
 -/
 
-example (a b c d e : mynat) :
-(((a+b)+c)+d)+e=(c+((b+e)+a))+d := begin
+lemma example_2_6 (a b c d e : mynat) :
+(((a+b)+c)+d)+e=(c+((b+e)+a))+d := 
+begin
   simp
 end 
 

--- a/src/game/world3/level9.lean
+++ b/src/game/world3/level9.lean
@@ -38,7 +38,7 @@ attribute [simp] mul_assoc mul_comm mul_left_comm
 and all of a sudden Lean can automatically do levels which are
 very boring for a human, for example
 -/
-example (a b c d e : mynat) :
+lemma example_3_9 (a b c d e : mynat) :
 (((a*b)*c)*d)*e=(c*((b*e)*a))*d :=
 begin
   simp,

--- a/src/game/world5/level1.lean
+++ b/src/game/world5/level1.lean
@@ -97,7 +97,7 @@ $P$ is not an element of $P$, it's $p$ that is an element of $P$.
 Given an element of $P$ and a function from $P$ to $Q$,
 we define an element of $Q$.
 -/
-example (P Q : Type) (p : P) (h : P → Q) : Q :=
+lemma example_5_1 (P Q : Type) (p : P) (h : P → Q) : Q :=
 begin
 exact h(p),
 

--- a/src/game/world5/level2.lean
+++ b/src/game/world5/level2.lean
@@ -120,7 +120,7 @@ will close the goal, ultimately defining the function $f(n)=3n+2$.
 /- Definition
 We define a function from mynat to mynat.
 -/
-example : mynat → mynat :=
+lemma example_5_2 : mynat → mynat :=
 begin
   intro n,
   exact 3*n+2,

--- a/src/game/world5/level3.lean
+++ b/src/game/world5/level3.lean
@@ -110,7 +110,7 @@ and then finish the level with
 /- Definition
 Given an element of $P$ we can define an element of $U$.
 -/
-example (P Q R S T U: Type)
+lemma example_5_3 (P Q R S T U: Type)
 (p : P)
 (h : P → Q)
 (i : Q → R)

--- a/src/game/world5/level4.lean
+++ b/src/game/world5/level4.lean
@@ -54,7 +54,7 @@ not an element of $P$).
 /- Definition
 Given an element of $P$ we can define an element of $U$.
 -/
-example (P Q R S T U: Type)
+lemma example_5_4 (P Q R S T U: Type)
 (p : P)
 (h : P → Q)
 (i : Q → R)

--- a/src/game/world5/level5.lean
+++ b/src/game/world5/level5.lean
@@ -44,7 +44,7 @@ and then let's output `p`.
 /- Definition
 We define an element of $\operatorname{Hom}(P,\operatorname{Hom}(Q,P))$.
 -/
-example (P Q : Type) : P → (Q → P) :=
+lemma example_5_5 (P Q : Type) : P → (Q → P) :=
 begin
   intro p,
   intro q,

--- a/src/game/world5/level6.lean
+++ b/src/game/world5/level6.lean
@@ -32,7 +32,7 @@ Whatever the sets $P$ and $Q$ and $R$ are, we
 make an element of $\operatorname{Hom}(\operatorname{Hom}(P,\operatorname{Hom}(Q,R)),
 \operatorname{Hom}(\operatorname{Hom}(P,Q),\operatorname{Hom}(P,R)))$.
 -/
-example (P Q R : Type) : (P → (Q → R)) → ((P → Q) → (P → R)) :=
+lemma example_5_6 (P Q R : Type) : (P → (Q → R)) → ((P → Q) → (P → R)) :=
 begin
   intro f,
   intro h,

--- a/src/game/world5/level7.lean
+++ b/src/game/world5/level7.lean
@@ -18,7 +18,7 @@ Whatever the sets $P$ and $Q$ and $F$ are, we
 make an element of $\operatorname{Hom}(\operatorname{Hom}(P,Q),
 \operatorname{Hom}(\operatorname{Hom}(Q,F),\operatorname{Hom}(P,F)))$.
 -/
-example (P Q F : Type) : (P → Q) → ((Q → F) → (P → F)) :=
+lemma example_5_7 (P Q F : Type) : (P → Q) → ((Q → F) → (P → F)) :=
 begin
   intro f,
   intro h,

--- a/src/game/world5/level8.lean
+++ b/src/game/world5/level8.lean
@@ -39,7 +39,7 @@ Whatever the sets $P$ and $Q$ are, we
 make an element of $\operatorname{Hom}(\operatorname{Hom}(P,Q),
 \operatorname{Hom}(\operatorname{Hom}(Q,\emptyset),\operatorname{Hom}(P,\emptyset)))$.
 -/
-example (P Q : Type) : (P → Q) → ((Q → empty) → (P → empty)) :=
+lemma example_5_8 (P Q : Type) : (P → Q) → ((Q → empty) → (P → empty)) :=
 begin
   intros f h p,
   apply h,

--- a/src/game/world5/level9.lean
+++ b/src/game/world5/level9.lean
@@ -15,7 +15,7 @@ You can of course work both forwards and backwards, or you could crack and draw 
 /- Definition
 Given a bunch of functions, we can define another one.
 -/
-example (A B C D E F G H I J K L : Type)
+lemma example_5_9 (A B C D E F G H I J K L : Type)
 (f1 : A → B) (f2 : B → E) (f3 : E → D) (f4 : D → A) (f5 : E → F)
 (f6 : F → C) (f7 : B → C) (f8 : F → G) (f9 : G → J) (f10 : I → J)
 (f11 : J → I) (f12 : I → H) (f13 : E → H) (f14 : H → K) (f15 : I → L)

--- a/src/game/world6/level1.lean
+++ b/src/game/world6/level1.lean
@@ -76,7 +76,7 @@ In Lean, Propositions, like sets, are types, and proofs, like elements of sets, 
 /- Lemma : no-side-bar
 If $P$ is true, and $P\implies Q$ is also true, then $Q$ is true.
 -/
-example (P Q : Prop) (p : P) (h : P → Q) : Q :=
+lemma example_6_1 (P Q : Prop) (p : P) (h : P → Q) : Q :=
 begin
 exact h(p),
 

--- a/src/game/world6/level5.lean
+++ b/src/game/world6/level5.lean
@@ -45,7 +45,7 @@ and now we have to prove $P$, but have a proof handy:
 For any propositions $P$ and $Q$, we always have
 $P\implies(Q\implies P)$. 
 -/
-example (P Q : Prop) : P → (Q → P) :=
+lemma example_6_5 (P Q : Prop) : P → (Q → P) :=
 begin
   intro p,
   intro q,

--- a/src/game/world6/level6.lean
+++ b/src/game/world6/level6.lean
@@ -21,7 +21,7 @@ What happens if you just try `apply f`? Can you figure out what just happened? T
 If $P$ and $Q$ and $R$ are true/false statements, then
 $$(P\implies(Q\implies R))\implies((P\implies Q)\implies(P\implies R)).$$
 -/
-example (P Q R : Prop) : (P → (Q → R)) → ((P → Q) → (P → R)) :=
+lemma example_6_6 (P Q R : Prop) : (P → (Q → R)) → ((P → Q) → (P → R)) :=
 begin
   intro f,
   intro h,

--- a/src/game/world6/level9.lean
+++ b/src/game/world6/level9.lean
@@ -10,7 +10,7 @@ Perhaps I should have mentioned it earlier.
 /- Lemma : no-side-bar
 There is a way through the following maze.
 -/
-example (A B C D E F G H I J K L : Prop)
+lemma example_6_9 (A B C D E F G H I J K L : Prop)
 (f1 : A → B) (f2 : B → E) (f3 : E → D) (f4 : D → A) (f5 : E → F)
 (f6 : F → C) (f7 : B → C) (f8 : F → G) (f9 : G → J) (f10 : I → J)
 (f11 : J → I) (f12 : I → H) (f13 : E → H) (f14 : H → K) (f15 : I → L)

--- a/src/game/world7/level1.lean
+++ b/src/game/world7/level1.lean
@@ -19,7 +19,7 @@ you will be able to finish off the goals with the `exact` tactic.
 /- Lemma : no-side-bar
 If $P$ and $Q$ are true, then $P\land Q$ is true.
 -/
-example (P Q : Prop) (p : P) (q : Q) : P ∧ Q :=
+lemma example_7_1 (P Q : Prop) (p : P) (q : Q) : P ∧ Q :=
 begin
   split,
   exact p,

--- a/src/game/world7/level6.lean
+++ b/src/game/world7/level6.lean
@@ -20,7 +20,7 @@ to an impossible goal, the other to an easy finish.
 If $P$ and $Q$ are true/false statements, then
 $$Q\implies(P\lor Q).$$ 
 -/
-example (P Q : Prop) : Q → (P ∨ Q) :=
+lemma example_7_6 (P Q : Prop) : Q → (P ∨ Q) :=
 begin
   intro q,
   right,

--- a/src/game/world8/level2.lean
+++ b/src/game/world8/level2.lean
@@ -39,20 +39,20 @@ with `succ_inj` -- `rw` works only with equalities or `↔` statements,
 not implications or functions.
 
 -/
-example {a b : mynat} (h : succ(succ(a)) = succ(succ(b))) :  a = b := 
+lemma example_8_2_1 {a b : mynat} (h : succ(succ(a)) = succ(succ(b))) :  a = b := 
 begin
   apply succ_inj,
   apply succ_inj,
   exact h
 end 
 
-example {a b : mynat} (h : succ(succ(a)) = succ(succ(b))) :  a = b := 
+lemma example_8_2_2 {a b : mynat} (h : succ(succ(a)) = succ(succ(b))) :  a = b := 
 begin
   apply succ_inj,
   exact succ_inj(h),
 end 
 
-example {a b : mynat} (h : succ(succ(a)) = succ(succ(b))) :  a = b := 
+lemma example_8_2_3 {a b : mynat} (h : succ(succ(a)) = succ(succ(b))) :  a = b := 
 begin
   exact succ_inj(succ_inj(h)),
 end 


### PR DESCRIPTION
For 22 theorems in natural number game there is a missing lemma keyword before the name of the theorem.